### PR TITLE
perf: added concurrency methods and a switch on cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ build:
 	mkdir -p $(BIN_DIR)
 	go test
 	go build -o $(BIN_DIR)/$(CLI_NAME) $(CLI_PATH)
+
+benchmark:
+	go test -bench=.

--- a/asciify.go
+++ b/asciify.go
@@ -16,3 +16,18 @@ func ConvertImageToAscii(imagePath string, width int) (string, error) {
 	asciiRepString := imageToAscii(originalImage, width)
 	return asciiRepString, nil
 }
+
+func ConvertImageToAsciiConcurrent(imagePath string, width int) (string, error) {
+	if fileNotExists(imagePath) {
+		return "", errors.New("imagePath is not valid")
+	}
+	if width < 10 {
+		return "", errors.New("width cannot be lesser than 10")
+	}
+	originalImage, err := readImage(imagePath)
+	if err != nil {
+		return "", err
+	}
+	asciiRepString := imageToAsciiConcurrent(originalImage, width)
+	return asciiRepString, nil
+}

--- a/asciify_test.go
+++ b/asciify_test.go
@@ -1,6 +1,8 @@
 package asciify
 
 import (
+	"image"
+	"image/color"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,5 +25,49 @@ func TestImageToASCII(t *testing.T) {
 
 	if !(outputString == string(expectedString)) {
 		t.Fatal("The expected string does not match the actual string")
+	}
+}
+
+func TestImageToASCIIConcurrent(t *testing.T) {
+	basePath := "testdata"
+	testImagePath := filepath.Join(basePath, "portrait_table.jpg")
+	expectedOutputFilePath := filepath.Join(basePath, "expected_output.txt")
+
+	expectedString, err := os.ReadFile(expectedOutputFilePath)
+	if err != nil {
+		t.Fatalf("failed to read expected output file: %v", err)
+	}
+
+	outputString, err := ConvertImageToAsciiConcurrent(testImagePath, 150)
+	if err != nil {
+		t.Fatalf("failed to convert image to ascii: %v", err)
+	}
+
+	if !(outputString == string(expectedString)) {
+		t.Fatal("The expected string does not match the actual string")
+	}
+}
+
+func BenchmarkGenerateAscii(b *testing.B) {
+	largeImage := image.NewRGBA(image.Rectangle{image.Point{0, 0}, image.Point{7680, 4320}})
+	for rowIdx := range largeImage.Bounds().Dy() {
+		for colIdx := range largeImage.Bounds().Dx() {
+			largeImage.SetRGBA(colIdx, rowIdx, color.RGBA{255, 255, 255, 255})
+		}
+	}
+	for range 1000 {
+		imageToAscii(largeImage, 150)
+	}
+}
+
+func BenchmarkGenerateAsciiConcurrent(b *testing.B) {
+	largeImage := image.NewRGBA(image.Rectangle{image.Point{0, 0}, image.Point{7680, 4320}})
+	for rowIdx := range largeImage.Bounds().Dy() {
+		for colIdx := range largeImage.Bounds().Dx() {
+			largeImage.SetRGBA(colIdx, rowIdx, color.RGBA{255, 255, 255, 255})
+		}
+	}
+	for range 1000 {
+		imageToAsciiConcurrent(largeImage, 150)
 	}
 }

--- a/cmd/asciifycli/main.go
+++ b/cmd/asciifycli/main.go
@@ -10,13 +10,24 @@ import (
 
 func main() {
 	path := flag.String("path", "", "Path to a valid the image")
-	width := flag.Int("width", 150, "Width of the output sequence of characters (default 150)")
+	width := flag.Int("width", 150, "Width of the output sequence of characters (optional - default 150)")
+	noConcurrency := flag.Bool("no-concurrency", false, "Switch off concurrency (optional - default false)")
 	flag.Parse()
-	asciiRepString, err := asciify.ConvertImageToAscii(*path, *width)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
-		flag.Usage()
-		os.Exit(1)
+	if *noConcurrency {
+		asciiRepString, err := asciify.ConvertImageToAscii(*path, *width)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+			flag.Usage()
+			os.Exit(1)
+		}
+		fmt.Print(asciiRepString)
+	} else {
+		asciiRepString, err := asciify.ConvertImageToAsciiConcurrent(*path, *width)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+			flag.Usage()
+			os.Exit(1)
+		}
+		fmt.Print(asciiRepString)
 	}
-	fmt.Print(asciiRepString)
 }

--- a/image_handler.go
+++ b/image_handler.go
@@ -6,7 +6,19 @@ import (
 	_ "image/jpeg"
 	"image/png"
 	"os"
+	"sync"
 )
+
+type RowRep struct {
+	inputImage image.Image
+	rowIdx     int
+	colIdx     int
+	scaleX     float32
+	scaleY     float32
+}
+
+var asciiArtChars string = "$@&M*oahwmO0UYcvf/(1{[]-_+~<>i!I;,`'."
+var characterIndexDivideFactor float32 = float32(256 / len(asciiArtChars))
 
 func writePNGImage(inputImage image.Image, outputPath string) error {
 	file, err := os.Create(outputPath)
@@ -31,31 +43,83 @@ func readImage(sourcePath string) (image.Image, error) {
 	return img, nil
 }
 
-func imageToAscii(originalImage image.Image, RW int) string {
+func processRow(rowData RowRep) float32 {
+	originalX := int(float32(rowData.colIdx) * rowData.scaleX)
+	originalY := int(float32(rowData.rowIdx) * rowData.scaleY)
+	R, G, B, _ := rowData.inputImage.At(originalX, originalY).RGBA()
+	r, g, b := float32(R>>8), float32(G>>8), float32(B>>8)
+	grayPixel := (r * 0.2989) + (g * 0.5870) + (b * 0.1140)
+	return grayPixel
+}
+
+func imageToAsciiConcurrent(originalImage image.Image, RW int) string {
 	OW := originalImage.Bounds().Dx()
 	OH := originalImage.Bounds().Dy()
 	RH := int(float32(RW)*float32(OH)/float32(OW)) / 2
 	resizedImage := image.NewRGBA(image.Rect(0, 0, RW, RH))
 	scaleX := float32(OW) / float32(RW)
 	scaleY := float32(OH) / float32(RH)
-	asciiArtChars := "$@&M*oahwmO0UYcvf/(1{[]-_+~<>i!I;,`'."
-	characterIndexDivideFactor := float32(256 / len(asciiArtChars))
 
-	outputString := ""
+	rows := resizedImage.Bounds().Dy()
+
+	var wg sync.WaitGroup
+	outputLines := make([]string, rows)
 
 	for rowIdx := range resizedImage.Bounds().Dy() {
+		wg.Add(1)
+		go func(rowIdx int) {
+			defer wg.Done()
+			rowString := ""
+			for colIdx := range resizedImage.Bounds().Dx() {
+				rowData := RowRep{
+					originalImage,
+					rowIdx,
+					colIdx,
+					scaleX,
+					scaleY,
+				}
+				grayPixel := processRow(rowData)
+				idx := int(grayPixel / characterIndexDivideFactor)
+				if idx >= len(asciiArtChars) {
+					idx = len(asciiArtChars) - 1
+				}
+				rowString = rowString + string(asciiArtChars[idx])
+			}
+			outputLines[rowIdx] = rowString
+		}(rowIdx)
+	}
+	wg.Wait()
+	outputString := ""
+	for _, line := range outputLines {
+		outputString += line + "\n"
+	}
+	return outputString
+}
+
+func imageToAscii(originalImage image.Image, RW int) string {
+	OW := originalImage.Bounds().Dx()
+	OH := originalImage.Bounds().Dy()
+	RH := int(float32(RW)*float32(OH)/float32(OW)) / 2
+	scaleX := float32(OW) / float32(RW)
+	scaleY := float32(OH) / float32(RH)
+
+	outputString := ""
+	for rowIdx := range RH {
 		rowString := ""
-		for colIdx := range resizedImage.Bounds().Dx() {
-			originalX := int(float32(colIdx) * scaleX)
-			originalY := int(float32(rowIdx) * scaleY)
-			R, G, B, _ := originalImage.At(originalX, originalY).RGBA()
-			r, g, b := float32(R>>8), float32(G>>8), float32(B>>8)
-			grayPixel := (r * 0.2989) + (g * 0.5870) + (b * 0.1140)
+		for colIdx := range RW {
+			rowData := RowRep{
+				originalImage,
+				rowIdx,
+				colIdx,
+				scaleX,
+				scaleY,
+			}
+			grayPixel := processRow(rowData)
 			idx := int(grayPixel / characterIndexDivideFactor)
 			if idx >= len(asciiArtChars) {
 				idx = len(asciiArtChars) - 1
 			}
-			rowString = rowString + (string(asciiArtChars[idx]))
+			rowString = rowString + string(asciiArtChars[idx])
 		}
 		outputString = outputString + rowString + "\n"
 	}


### PR DESCRIPTION
# Performance Improvements

## Library:

Added a new exposed method that can concurrently process rows of the image

## CLI:

Switched default processing to the concurrent method and added a flag to run non concurrently 
```bash
-no-concurrency
```

# Makefile

Added target to run benchmark

```bash
make benchmark
```